### PR TITLE
Support for Multiple Nodes

### DIFF
--- a/examples/export.py
+++ b/examples/export.py
@@ -1,21 +1,23 @@
 from systemrdl import RDLCompiler
 from peakrdl_halcpp import HalExporter
 
-rdlc = RDLCompiler()
-rdlc.compile_file("atxmega_spi.rdl")
+rdl_files = ["atxmega_spi.rdl", "regs_and_mem.rdl"]
 
-root = rdlc.elaborate()
-top_gen = root.children(unroll=True)
+for rdl_file in rdl_files:
+    rdlc = RDLCompiler()
+    rdlc.compile_file(rdl_file)
 
-top = None
-for top in top_gen:
-    top = top
-assert top is not None
+    root = rdlc.elaborate()
+    top_gen = root.children(unroll=True)
 
-exporter = HalExporter()
+    top = None
+    for top in top_gen:
+        top = top
+    assert top is not None
 
-exporter.export(
-        node=top,
-        outdir="generated",
-        )
+    exporter = HalExporter()
 
+    exporter.export(
+            node=top,
+            outdir="generated",
+            )

--- a/examples/generated/include/field_node.h
+++ b/examples/generated/include/field_node.h
@@ -24,19 +24,16 @@ namespace halcpp
     {
     public:
         /**
-         * @brief
+         * @brief Return the absolute address of the node.
          *
          */
         static constexpr uint32_t get_abs_addr() { return PARENT_TYPE().get_abs_addr(); }
 
-    protected:
-        using parent_type = PARENT_TYPE;
-        using dataType = typename std::conditional<width <= 8, uint8_t,
-                                                   typename std::conditional<width <= 16, uint16_t, uint32_t>::type>::type;
-
-        static constexpr uint32_t start_bit = START_BIT;
-        static constexpr uint32_t end_bit = END_BIT;
-        static constexpr uint32_t width = END_BIT - START_BIT + 1;
+        /**
+         * @brief Return the width of the field noe.
+         *
+         */
+        static constexpr uint32_t get_width() { return width; }
 
         /**
          * @brief Calculate the field mask.
@@ -58,6 +55,18 @@ namespace halcpp
         {
             return (((1u << (width)) - 1));
         }
+
+
+
+    protected:
+        using parent_type = PARENT_TYPE;
+
+        static constexpr uint32_t start_bit = START_BIT;
+        static constexpr uint32_t end_bit = END_BIT;
+        static constexpr uint32_t width = END_BIT - START_BIT + 1;
+
+        using dataType = typename std::conditional<width <= 8, uint8_t,
+                                                   typename std::conditional<width <= 16, uint16_t, uint32_t>::type>::type;
     };
 
     /**

--- a/examples/generated/include/halcpp_base.h
+++ b/examples/generated/include/halcpp_base.h
@@ -3,24 +3,12 @@
 
 #include <stdint.h>
 #include <type_traits>
+#include "halcpp_utils.h"
 #include "field_node.h"
 #include "reg_node.h"
-#include "csr_reg_node.h"
-#include "reg_arr_node.h"
+#include "regfile_node.h"
+#include "array_nodes.h"
+#include "mem_node.h"
 #include "addrmap_node.h"
-
-
-template <uint32_t BASE, uint32_t SIZE, typename PARENT_TYPE>
-class MemNode {
-public:
-
-    static constexpr uint32_t base = BASE;
-    static constexpr uint32_t size = SIZE;
-
-    inline uint32_t get(const uint32_t addr) { return PARENT_TYPE::get(addr + BASE); }
-    inline void set(const uint32_t addr, uint32_t val) { PARENT_TYPE::set(addr + BASE, val); }
-    static constexpr uint32_t get_abs_addr() { return PARENT_TYPE().get_abs_addr() + BASE; }
-    constexpr uint32_t get_size() { return SIZE; }
-};
 
 #endif

--- a/examples/generated/regs_and_mem_hal.h
+++ b/examples/generated/regs_and_mem_hal.h
@@ -27,10 +27,10 @@ namespace regs_and_mem_nm
 
     
     template <uint32_t BASE, uint32_t WIDTH, typename PARENT_TYPE>
-    class CSR_2 : public halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>
+    class CSR2 : public halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>
     {
     public:
-        using TYPE = CSR_2<BASE, WIDTH, PARENT_TYPE>;
+        using TYPE = CSR2<BASE, WIDTH, PARENT_TYPE>;
 
         static halcpp::FieldRW<0, 7, TYPE> ctrl;
 
@@ -59,7 +59,7 @@ public:
     using TYPE = REGS_AND_MEM_HAL<BASE, PARENT_TYPE>;
 
     static regs_and_mem_nm::CSR<0x0, 8, TYPE> csr;
-    static regs_and_mem_nm::CSR_2<0x4, 8, TYPE> csr_2;
+    static regs_and_mem_nm::CSR2<0x4, 8, TYPE> csr2;
     static regs_and_mem_nm::MEM1<0x1000, 256, TYPE> mem1;
     static regs_and_mem_nm::MEM2_T<0x2000, 256, TYPE> mem2;
 };

--- a/examples/generated/regs_and_mem_hal.h
+++ b/examples/generated/regs_and_mem_hal.h
@@ -1,0 +1,67 @@
+// Generated with PeakRD-halcpp : https://github.com/Risto97/PeakRDL-halcpp
+#ifndef __REGS_AND_MEM_HAL_H_
+#define __REGS_AND_MEM_HAL_H_
+
+#include <stdint.h>
+#include "include/halcpp_base.h"
+
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wundefined-var-template"
+#endif
+
+namespace regs_and_mem_nm
+{
+
+    
+    template <uint32_t BASE, uint32_t WIDTH, typename PARENT_TYPE>
+    class CSR : public halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>
+    {
+    public:
+        using TYPE = CSR<BASE, WIDTH, PARENT_TYPE>;
+
+        static halcpp::FieldRW<0, 7, TYPE> ctrl;
+
+        using halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>::operator=;
+    };
+
+
+    
+    template <uint32_t BASE, uint32_t WIDTH, typename PARENT_TYPE>
+    class CSR_2 : public halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>
+    {
+    public:
+        using TYPE = CSR_2<BASE, WIDTH, PARENT_TYPE>;
+
+        static halcpp::FieldRW<0, 7, TYPE> ctrl;
+
+        using halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>::operator=;
+    };
+
+
+
+    template <uint32_t BASE, uint32_t SIZE, typename PARENT_TYPE>
+    class MEM1 : public halcpp::MemNode<BASE, SIZE, PARENT_TYPE>
+    {
+
+    };
+    template <uint32_t BASE, uint32_t SIZE, typename PARENT_TYPE>
+    class MEM2_T : public halcpp::MemNode<BASE, SIZE, PARENT_TYPE>
+    {
+
+    };
+}
+
+
+template <uint32_t BASE, typename PARENT_TYPE=void>
+class REGS_AND_MEM_HAL : public AddrmapNode<BASE, PARENT_TYPE>
+{
+public:
+    using TYPE = REGS_AND_MEM_HAL<BASE, PARENT_TYPE>;
+
+    static regs_and_mem_nm::CSR<0x0, 8, TYPE> csr;
+    static regs_and_mem_nm::CSR_2<0x4, 8, TYPE> csr_2;
+    static regs_and_mem_nm::MEM1<0x1000, 256, TYPE> mem1;
+    static regs_and_mem_nm::MEM2_T<0x2000, 256, TYPE> mem2;
+};
+
+#endif // !__REGS_AND_MEM_HAL_H_

--- a/examples/regs_and_mem.rdl
+++ b/examples/regs_and_mem.rdl
@@ -1,0 +1,26 @@
+addrmap regs_and_mem {
+    name = "Registers and Memory Example";
+    default regwidth = 32;
+
+    reg {
+        field { sw=rw; hw=r; } ctrl[7:0];
+    } csr @0x0;
+
+    reg {
+        field { sw=rw; hw=r; } ctrl[7:0];
+    } csr2 @0x4;
+
+    // anonymous definition of mem (SystemRDL 11.1.b)
+    mem {
+        memwidth = 32;
+        mementries = 64;
+    } external mem1 @0x1000;
+
+    // definitive definition of mem (SystemRDL 11.1.a)
+    mem mem2_t {
+        memwidth = 32;
+        mementries = 64;
+    };
+
+    external mem2_t mem2 @0x2000;
+};

--- a/src/peakrdl_halcpp/halnode.py
+++ b/src/peakrdl_halcpp/halnode.py
@@ -353,14 +353,6 @@ class HalMemNode(HalBaseNode, MemNode):
 
         self.bus_offset = 0
 
-        # Memory component instantiation is limited for simplicity
-        if self.parent is not None:
-            for c in self.parent.children():
-                if isinstance(c, AddressableNode):
-                    assert c.inst == self.inst, (f"Addrmaps with anything else than "
-                                                 "one memory node is currently not allowed, "
-                                                 "it could be easily added")
-
     @property
     def address_offset(self) -> int:
         """Property adapted HalRegNode class."""

--- a/src/peakrdl_halcpp/templates/addrmap.h.j2
+++ b/src/peakrdl_halcpp/templates/addrmap.h.j2
@@ -127,7 +127,7 @@ namespace {{ halnode.orig_type_name }}_nm
     {# ======== 4. Generate the memory classes ======== #}
     {% for m in halnode.halchildren(children_type=HalMemNode, skip_buses=skip_buses, unique_orig_type=True) %}
     {{ m.get_template_line() }}
-    class {{ m.parent.orig_type_name|upper }} : public halcpp::MemNode{{ m.get_cls_tmpl_params() }}
+    class {{ m.orig_type_name|upper }} : public halcpp::MemNode{{ m.get_cls_tmpl_params() }}
     {
 
     };
@@ -153,7 +153,7 @@ public:
     {% elif c.__class__.__name__ == "HalRegfileNode" %}
     static {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, TYPE> {{ c.inst_name }};
     {% elif c.__class__.__name__ == "HalMemNode" %}
-    static {{ halnode.orig_type_name }}_nm::{{ c.parent.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.size }}, TYPE> {{ c.inst_name }};
+    static {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.size }}, TYPE> {{ c.inst_name }};
     {% else %}
     static {{ halutils.get_extern(c)|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, TYPE> {{ c.inst_name }};
     {% endif %}


### PR DESCRIPTION
This PR removes the assertion blocking the use of multiple memory nodes, allowing uses such as registers and memories in the same addrmap.

A change is also made in `addrmap.h.j2`, where memories were assigned the name of their parent class instead of their own names, allowing for the use of multiple mem types in one addrmap. Previously, this resulted in the classes in the generated header having identical names.

A test description `regs_and_mem.rdl` is added which places multiple registers and memories in the same addrmap. Its generated output is also committed, and a loop is added to `export.py` to support multiple `.rdl` examples.