### PR TITLE
generate parameters as constexprs

### DIFF
--- a/src/peakrdl_halcpp/exporter.py
+++ b/src/peakrdl_halcpp/exporter.py
@@ -104,6 +104,7 @@ class HalExporter():
         for halnode in concatenated_iterable:
             # Create the context for the template generation
             context = {
+                'parameters': halnode.parameters.items(),
                 'halnode': halnode,
                 'halutils': halutils,
                 'skip_buses': skip_buses,

--- a/src/peakrdl_halcpp/templates/addrmap.h.j2
+++ b/src/peakrdl_halcpp/templates/addrmap.h.j2
@@ -6,6 +6,7 @@
 #define __{{ halnode.orig_type_name_hal|upper }}_H_
 
 #include <stdint.h>
+#include <string_view>
 #include "include/halcpp_base.h"
 
 #if defined(__clang__)
@@ -21,6 +22,20 @@
 {% if not halnode.is_bus %}
 namespace {{ halnode.orig_type_name }}_nm
 {
+    {# =========== 0. Generate constants =========== -#}
+    {% for name, value in parameters %}
+    {% if value is boolean %}
+    constexpr bool {{name}} = {{value}};
+    {% elif value is number %}
+    {# According to SystemRDL spec 6.2.1 all numbers are integral and unsigned.
+       and only supports `bits` and `longint unsigned`. 
+       However register size is 32bit, for that they will interpreted as uin32_t #}
+    constexpr uint32_t {{name}} = {{value}};
+    {% elif value is string %}
+    constexpr std::string_view {{name}} = "{{value}}";
+    {% endif %}
+    {% endfor %}
+
     {#- Enum with same name are not duplicated -#}
     {%- set seen_enum_names = [] -%}
 


### PR DESCRIPTION
parameters defined in addrmap are now generated,
In an rdl like below

```
addrmap atxmega #(
    longint unsigned VER_MAJOR = 0,
    longint unsigned VER_MINOR = 1,

    longint SOME_MINUS_CONSTANT = -10000000, // This is a problem, those are converted to 2's complement unsigned ints by the rdlcompiler, and they are not represented correctly.
    longint SOME_CONSTANT = 1234
) {
....
}
```
this is generated as below
```
namespace atxmega_nm
{
    constexpr uint32_t VER_MAJOR = 0;
    constexpr uint32_t VER_MINOR = 1;
    constexpr uint32_t SOME_MINUS_CONSTANT = 18446744073699551616;
    constexpr uint32_t SOME_CONSTANT = 1234;

....
```