### PR TITLE
Assignment operator fails to link

### DIFF
--- a/examples/generated/atxmega_spi_hal.h
+++ b/examples/generated/atxmega_spi_hal.h
@@ -5,10 +5,6 @@
 #include <stdint.h>
 #include "include/halcpp_base.h"
 
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wundefined-var-template"
-#endif
-
 namespace atxmega_spi_nm
 {
 
@@ -19,12 +15,12 @@ namespace atxmega_spi_nm
     public:
         using TYPE = CTRL<BASE, WIDTH, PARENT_TYPE>;
 
-        static halcpp::FieldRW<0, 1, TYPE> PRESCALER;
-        static halcpp::FieldRW<2, 3, TYPE> MODE;
-        static halcpp::FieldRW<4, 4, TYPE> MASTER;
-        static halcpp::FieldRW<5, 5, TYPE> DORD;
-        static halcpp::FieldRW<6, 6, TYPE> ENABLE;
-        static halcpp::FieldRW<7, 7, TYPE> CLK2X;
+        static inline halcpp::FieldRW<0, 1, TYPE> PRESCALER;
+        static inline halcpp::FieldRW<2, 3, TYPE> MODE;
+        static inline halcpp::FieldRW<4, 4, TYPE> MASTER;
+        static inline halcpp::FieldRW<5, 5, TYPE> DORD;
+        static inline halcpp::FieldRW<6, 6, TYPE> ENABLE;
+        static inline halcpp::FieldRW<7, 7, TYPE> CLK2X;
 
         using halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>::operator=;
     };
@@ -37,7 +33,7 @@ namespace atxmega_spi_nm
     public:
         using TYPE = INTCTRL<BASE, WIDTH, PARENT_TYPE>;
 
-        static halcpp::FieldRW<0, 1, TYPE> INTLVL;
+        static inline halcpp::FieldRW<0, 1, TYPE> INTLVL;
 
         using halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>::operator=;
     };
@@ -50,8 +46,8 @@ namespace atxmega_spi_nm
     public:
         using TYPE = STATUS<BASE, WIDTH, PARENT_TYPE>;
 
-        static halcpp::FieldRO<6, 6, TYPE> WRCOL;
-        static halcpp::FieldRO<7, 7, TYPE> IF;
+        static inline halcpp::FieldRO<6, 6, TYPE> WRCOL;
+        static inline halcpp::FieldRO<7, 7, TYPE> IF;
     };
 
 
@@ -68,8 +64,8 @@ namespace atxmega_spi_nm
     public:
         using TYPE = DATA<BASE, WIDTH, PARENT_TYPE>;
 
-        static halcpp::FieldWO<0, 7, TYPE> WDATA;
-        static halcpp::FieldRO<0, 7, TYPE> RDATA;
+        static inline halcpp::FieldWO<0, 7, TYPE> WDATA;
+        static inline halcpp::FieldRO<0, 7, TYPE> RDATA;
 
         using halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>::operator=;
     };
@@ -89,10 +85,10 @@ class ATXMEGA_SPI_HAL : public AddrmapNode<BASE, PARENT_TYPE>
 public:
     using TYPE = ATXMEGA_SPI_HAL<BASE, PARENT_TYPE>;
 
-    static atxmega_spi_nm::CTRL<0x0, 8, TYPE> CTRL;
-    static atxmega_spi_nm::INTCTRL<0x1, 2, TYPE> INTCTRL;
-    static atxmega_spi_nm::STATUS<0x2, 8, TYPE> STATUS;
-    static atxmega_spi_nm::DATA<0x3, 8, TYPE> DATA;
+    static inline atxmega_spi_nm::CTRL<0x0, 8, TYPE> CTRL;
+    static inline atxmega_spi_nm::INTCTRL<0x1, 2, TYPE> INTCTRL;
+    static inline atxmega_spi_nm::STATUS<0x2, 8, TYPE> STATUS;
+    static inline atxmega_spi_nm::DATA<0x3, 8, TYPE> DATA;
 };
 
 #endif // !__ATXMEGA_SPI_HAL_H_

--- a/examples/generated/include/field_node.h
+++ b/examples/generated/include/field_node.h
@@ -53,7 +53,11 @@ namespace halcpp
          */
         static constexpr uint32_t bit_mask()
         {
-            return (((1u << (width)) - 1));
+            if constexpr (width >= 32) {
+                return ~0u;
+            } else {
+                return ((1u << width) - 1u);
+            }
         }
 
 

--- a/examples/generated/regs_and_mem_hal.h
+++ b/examples/generated/regs_and_mem_hal.h
@@ -5,10 +5,6 @@
 #include <stdint.h>
 #include "include/halcpp_base.h"
 
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wundefined-var-template"
-#endif
-
 namespace regs_and_mem_nm
 {
 
@@ -19,7 +15,7 @@ namespace regs_and_mem_nm
     public:
         using TYPE = CSR<BASE, WIDTH, PARENT_TYPE>;
 
-        static halcpp::FieldRW<0, 7, TYPE> ctrl;
+        static inline halcpp::FieldRW<0, 7, TYPE> ctrl;
 
         using halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>::operator=;
     };
@@ -32,7 +28,7 @@ namespace regs_and_mem_nm
     public:
         using TYPE = CSR2<BASE, WIDTH, PARENT_TYPE>;
 
-        static halcpp::FieldRW<0, 7, TYPE> ctrl;
+        static inline halcpp::FieldRW<0, 7, TYPE> ctrl;
 
         using halcpp::RegRW<BASE, WIDTH, PARENT_TYPE>::operator=;
     };
@@ -58,10 +54,10 @@ class REGS_AND_MEM_HAL : public AddrmapNode<BASE, PARENT_TYPE>
 public:
     using TYPE = REGS_AND_MEM_HAL<BASE, PARENT_TYPE>;
 
-    static regs_and_mem_nm::CSR<0x0, 8, TYPE> csr;
-    static regs_and_mem_nm::CSR2<0x4, 8, TYPE> csr2;
-    static regs_and_mem_nm::MEM1<0x1000, 256, TYPE> mem1;
-    static regs_and_mem_nm::MEM2_T<0x2000, 256, TYPE> mem2;
+    static inline regs_and_mem_nm::CSR<0x0, 8, TYPE> csr;
+    static inline regs_and_mem_nm::CSR2<0x4, 8, TYPE> csr2;
+    static inline regs_and_mem_nm::MEM1<0x1000, 256, TYPE> mem1;
+    static inline regs_and_mem_nm::MEM2_T<0x2000, 256, TYPE> mem2;
 };
 
 #endif // !__REGS_AND_MEM_HAL_H_

--- a/src/peakrdl_halcpp/templates/addrmap.h.j2
+++ b/src/peakrdl_halcpp/templates/addrmap.h.j2
@@ -8,10 +8,6 @@
 #include <stdint.h>
 #include "include/halcpp_base.h"
 
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wundefined-var-template"
-#endif
-
 {# Include the child addrmap nodes #}
 {% for child_addrmap in halnode.halchildren(children_type=HalAddrmapNode, skip_buses=skip_buses, unique_orig_type=True) %}
 #include "{{ halutils.get_include_file(child_addrmap) }}"
@@ -37,7 +33,7 @@ namespace {{ halnode.orig_type_name }}_nm
     {
     public:
     {% for  s, v, d in enum_strings|zip(enum_values, enum_desc) %}
-        static const halcpp::Const<{{ const_width }}, {{ v }}> {{ s }}; // {{ d }}
+        static inline const halcpp::Const<{{ const_width }}, {{ v }}> {{ s }}; // {{ d }}
     {% endfor %}
     };
     {% endif %}
@@ -53,7 +49,7 @@ namespace {{ halnode.orig_type_name }}_nm
 
     {# Add the fields to the register #}
     {% for f in r.halchildren(children_type=HalFieldNode, skip_buses=skip_buses) %}
-        static halcpp::{{ f.cpp_access_type }}<{{ f.low }}, {{ f.high }}, TYPE> {{ f.inst_name }};
+        static inline halcpp::{{ f.cpp_access_type }}<{{ f.low }}, {{ f.high }}, TYPE> {{ f.inst_name }};
     {% endfor %}
     {# Inherit the overloaded '=' operator from the base class if register can be write from software #}
     {% if r.has_sw_writable %}
@@ -77,7 +73,7 @@ namespace {{ halnode.orig_type_name }}_nm
     {
     public:
     {% for  s, v, d in enum_strings|zip(enum_values, enum_desc) %}
-        static const halcpp::Const<{{ const_width }}, {{ v }}> {{ s }}; // {{ d }}
+        static inline const halcpp::Const<{{ const_width }}, {{ v }}> {{ s }}; // {{ d }}
     {% endfor %}
     };
     {% endif %}
@@ -93,7 +89,7 @@ namespace {{ halnode.orig_type_name }}_nm
 
     {# Add the fields to the register #}
     {% for f in r.halchildren(children_type=HalFieldNode, skip_buses=skip_buses) %}
-        static halcpp::{{ f.cpp_access_type }}<{{ f.low }}, {{ f.high }}, TYPE> {{ f.inst_name }};
+        static inline halcpp::{{ f.cpp_access_type }}<{{ f.low }}, {{ f.high }}, TYPE> {{ f.inst_name }};
     {% endfor %}
     {# Inherit the overloaded '=' operator from the base class if register can be write from software #}
     {% if r.has_sw_writable %}
@@ -116,9 +112,9 @@ namespace {{ halnode.orig_type_name }}_nm
     {% for c in rf.halchildren((HalRegNode, HalRegfileNode), skip_buses=skip_buses) %}
 
         {% if c.__class__.__name__ == "HalRegNode" and c.is_array %}
-        static halcpp::RegArrayNode<{{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}, 0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, {{ c.array_stride }}, TYPE , {{ c.array_dimensions|join(', ') }}> {{ c.inst_name }};
+        static inline halcpp::RegArrayNode<{{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}, 0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, {{ c.array_stride }}, TYPE , {{ c.array_dimensions|join(', ') }}> {{ c.inst_name }};
         {% elif c.__class__.__name__ == "HalRegNode" %}
-        static {{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, TYPE> {{ c.inst_name }};
+        static inline {{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, TYPE> {{ c.inst_name }};
         {% endif %}
     {% endfor %}
     };
@@ -145,17 +141,17 @@ public:
 
 {% for c in halnode.halchildren(skip_buses=skip_buses) %}
     {% if c.__class__.__name__ == "HalRegNode" and c.is_array %}
-    static halcpp::RegArrayNode<{{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}, 0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, {{ c.array_stride }}, TYPE , {{ c.array_dimensions|join(', ') }}> {{ c.inst_name }};
+    static inline halcpp::RegArrayNode<{{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}, 0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, {{ c.array_stride }}, TYPE , {{ c.array_dimensions|join(', ') }}> {{ c.inst_name }};
     {% elif c.__class__.__name__ == "HalRegNode" %}
-    static {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, TYPE> {{ c.inst_name }};
+    static inline {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.width }}, TYPE> {{ c.inst_name }};
     {% elif c.__class__.__name__ == "HalRegfileNode" and c.is_array %}
-    static halcpp::RegfileArrayNode<{{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}, 0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.array_stride }}, TYPE , {{ c.array_dimensions|join(', ') }}> {{ c.inst_name }};
+    static inline halcpp::RegfileArrayNode<{{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}, 0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.array_stride }}, TYPE , {{ c.array_dimensions|join(', ') }}> {{ c.inst_name }};
     {% elif c.__class__.__name__ == "HalRegfileNode" %}
-    static {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, TYPE> {{ c.inst_name }};
+    static inline {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, TYPE> {{ c.inst_name }};
     {% elif c.__class__.__name__ == "HalMemNode" %}
-    static {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.size }}, TYPE> {{ c.inst_name }};
+    static inline {{ halnode.orig_type_name }}_nm::{{ c.orig_type_name|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, {{ c.size }}, TYPE> {{ c.inst_name }};
     {% else %}
-    static {{ halutils.get_extern(c)|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, TYPE> {{ c.inst_name }};
+    static inline {{ halutils.get_extern(c)|upper }}<0x{{ "%0x"|format(c.address_offset|int) }}, TYPE> {{ c.inst_name }};
     {% endif %}
 {% endfor %}
 };


### PR DESCRIPTION
Writing a field or register with = produces an undefined reference, so the assignment syntax presented in the api cannot be used